### PR TITLE
 Changing the commented doc to reflect the correct method name in `collection` object

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ async function run() {
   /*
    *  *** INSERT DOCUMENTS ***
    *
-   * You can insert individual documents using collection.insert().
+   * You can insert individual documents using collection.insertOne().
    * In this example, we're going to create four documents and then
    * insert them all in one call with collection.insertMany().
    */


### PR DESCRIPTION
There is no method named `insert` in the collection object, It should be corrected as `inserOne`

```
TypeError: collection.insert is not a function
```